### PR TITLE
OZ-497: Use `camel-openmrs-fhir` component.

### DIFF
--- a/erpnext-openmrs/dependency-reduced-pom.xml
+++ b/erpnext-openmrs/dependency-reduced-pom.xml
@@ -197,7 +197,7 @@
     <maven.compiler.source>17</maven.compiler.source>
     <dependencyReportClassifier>dependencies</dependencyReportClassifier>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <openmrs.fhir.version>4.0.0-SNAPSHOT</openmrs.fhir.version>
+    <camel.openmrs.fhir.version>4.0.0-SNAPSHOT</camel.openmrs.fhir.version>
     <camel.frappe.version>1.0.0-SNAPSHOT</camel.frappe.version>
     <camel.version>4.0.1</camel.version>
   </properties>

--- a/erpnext-openmrs/pom.xml
+++ b/erpnext-openmrs/pom.xml
@@ -27,7 +27,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <camel.frappe.version>1.0.0-SNAPSHOT</camel.frappe.version>
     <camel.version>4.0.1</camel.version>
-    <openmrs.fhir.version>4.0.0-SNAPSHOT</openmrs.fhir.version>
+    <camel.openmrs.fhir.version>4.0.0-SNAPSHOT</camel.openmrs.fhir.version>
 
     <!-- Classifier for the dependency report artifact -->
     <dependencyReportClassifier>dependencies</dependencyReportClassifier>
@@ -46,8 +46,8 @@
     </dependency>
     <dependency>
       <groupId>org.openmrs.eip</groupId>
-      <artifactId>openmrs-fhir</artifactId>
-      <version>${openmrs.fhir.version}</version>
+      <artifactId>camel-openmrs-fhir</artifactId>
+      <version>${camel.openmrs.fhir.version}</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Issue: https://mekomsolutions.atlassian.net/issues/OZ-497

- Use `camel-openmrs-fhir`.